### PR TITLE
Fix Desuarchive image redirects

### DIFF
--- a/src/Archive/Redirect.ts
+++ b/src/Archive/Redirect.ts
@@ -191,7 +191,7 @@ var Redirect = {
     } else {
       if (/[sm]\.jpg$/.test(filename)) { return ''; }
     }
-    if (archive.name.endsWith('arch.b4k.co') || archive.name.endsWith('palanq.win')) {
+    if (archive.name.endsWith('arch.b4k.co') || archive.name.endsWith('palanq.win') || archive.name.endsWith('Desuarchive')) {
       const [timeStamp, ext] = filename.split('.');
       if (timeStamp.length > 13) {
         // remove last 3 digits


### PR DESCRIPTION
Added Desuarchive to the redirect formatting. 

Fixes issue:

- #2

I checked that it fixes the link given in the original issue <sup>( https://github.com/TuxedoTako/4chan-xt/issues/202 )</sup> and also on recent images

Tested with Windows 11, Firefox 150, Violentmonkey. 

