### PR TITLE
A new button to the QR window to randomize image MD5

### DIFF
--- a/src/Icons/icon.ts
+++ b/src/Icons/icon.ts
@@ -30,6 +30,7 @@ import { svgPathData as playSvg, width as playW, height as playH } from "@fas/fa
 import { svgPathData as stopSvg, width as stopW, height as stopH } from "@fas/faStop";
 import { svgPathData as arrowUpLongSvg, width as arrowUpLongW, height as arrowUpLongH } from "@fas/faArrowUpLong";
 import { svgPathData as arrowDownLongSvg, width as arrowDownLongW, height as arrowDownLongH } from "@fas/faArrowDownLong";
+import { svgPathData as diceSvg, width as diceW, height as diceH } from "@fas/faDice";
 
 const toSvg = (svgPathData: string, width: string | number, height: string | number) => {
   return `<svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 ${width} ${height}">` +
@@ -66,7 +67,8 @@ const icons = {
    play:            toSvg(playSvg, playW, playH),
    stop:            toSvg(stopSvg, stopW, stopH),
    arrowUpLong:     toSvg(arrowUpLongSvg, arrowUpLongW, arrowUpLongH),
-   arrowDownLong:   toSvg(arrowDownLongSvg, arrowDownLongW, arrowDownLongH)
+   arrowDownLong:   toSvg(arrowDownLongSvg, arrowDownLongW, arrowDownLongH),
+   dice:            toSvg(diceSvg, diceW, diceH)
 } as const;
 
 var Icon = {

--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -88,6 +88,7 @@ var QR = {
     flag?: HTMLSelectElement,
     preview?: HTMLDivElement;
     splitPost?: HTMLAnchorElement;
+    rollMd5: HTMLAnchorElement;
   },
   shortcut: undefined as HTMLAnchorElement,
   hasFocus: false,
@@ -783,6 +784,7 @@ var QR = {
     setNode('drawButton',     '#qr-draw-button');
     setNode('randomizeButton','#qr-randomize');
     setNode('compress',       '#qr-jpg');
+    setNode('rollMd5',        '#qr-roll-md5')
     setNode('view',           '#qr-view');
     setNode('restoreNameButton','#qr-restore-name');
     setNode('fileSubmit',     '#file-n-submit');
@@ -833,6 +835,7 @@ var QR = {
     $.on(nodes.noFile,         'click',     QR.openFileInput);
     $.on(nodes.randomizeButton,'click',     () => { QR.selected.randomizeName(); });
     $.on(nodes.compress,       'click',     async () => { QR.handleFiles([await QR.convert(QR.selected.file)]); });
+    $.on(nodes.rollMd5,        'click',     async () => { QR.handleFiles([await QR.rollMd5(QR.selected.file)]); })
     $.on(nodes.view,           'click',     QR.preview);
     $.on(nodes.restoreNameButton,'click',   () => { QR.selected.restoreName(); });
     $.on(nodes.filename,       'focus',     function() { return $.addClass(this.parentNode, 'focus'); });
@@ -898,6 +901,7 @@ var QR = {
     Icon.set(nodes.customCooldown, 'clock');
     Icon.set(nodes.randomizeButton, 'shuffle');
     Icon.set(nodes.compress, 'shrink');
+    Icon.set(nodes.rollMd5, 'dice');
     Icon.set(nodes.view, 'eye');
     Icon.set(nodes.restoreNameButton, 'undo');
     Icon.set(nodes.splitPost, 'scissors');
@@ -1320,6 +1324,47 @@ var QR = {
     return newFile;
   },
 
+  /**
+   * Alters the pixel data of an image file slightly to change its MD5 hash.
+   * Only supports image files; returns the original file for unsupported types.
+   * @param file The image file to modify.
+   * @returns A Promise that resolves to a new File with a modified MD5 hash, or the original file if not supported.
+   */
+  async rollMd5(file: File): Promise<File> {
+
+    if (!file.type.startsWith("image/") || file.type === "image/gif") {
+      new Notice('warning', "MD5 change supports only static image files.")
+      return file;
+    }
+
+    return new Promise((resolve, reject) => {
+      const img= new Image();
+
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+
+        const ctx = canvas.getContext('2d');
+        if(!ctx) {
+          throw new Error(`Image MD5 canvas failed`);
+        }
+        ctx.drawImage(img, 0,0);
+        //flip one bit
+        const pixel = ctx.getImageData(0,0,1,1);
+        pixel.data[0] ^= 1;
+        ctx.putImageData(pixel, 0,0);
+        //re-encode
+        canvas.toBlob(blob => {
+          resolve(new File([blob!], file.name, { type: file.type}));
+        }, file.type, 0.98);
+      };
+
+    img.onerror = reject;
+    img.src = URL.createObjectURL(file);
+    });
+  },
+   
   previewUrl: undefined as string | undefined,
 
   preview() {

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -47,6 +47,7 @@
       <span id="qr-actions" class="row">
         <a href="javascript:;" id="qr-oekaki-button" class="qr-action-button" title="Edit in Tegaki">✎︎</a>
         <a href="javascript:;" id="qr-jpg" class="qr-action-button" title="Compress to jpg">C</a>
+        <a href="javascript:;" id="qr-roll-md5" class = "qr-action-button" title="Randomize md5">M</a>
         <a href="javascript:;" id="qr-view" class="qr-action-button" title="Preview">V</a>
         <a href="javascript:;" id="qr-randomize" class="qr-action-button" title="Randomize filename">R</a>
         <a href="javascript:;" id="qr-restore-name" class="qr-action-button" title="Reset filename">U</a>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1745,7 +1745,7 @@ input#qr-filename {
 }
 #qr:not(.has-spoiler) #qr-spoiler-label,
 #file-n-submit:not(.has-file) :is(#qr-spoiler-label, #qr-randomize, #qr-restore-name),
-#file-n-submit:not(.has-image) #qr-jpg,
+#file-n-submit:not(.has-image) :is(#qr-jpg, #qr-roll-md5),
 #file-n-submit:not(.has-image):not(.has-video) #qr-view,
 #file-n-submit.has-file :is(#paste-area, #url-button),
 #file-n-submit:not(.custom-cooldown) #custom-cooldown-button {


### PR DESCRIPTION
Added a new quick reply button to roll a new MD5 for static images

<img width="393" height="560" alt="image" src="https://github.com/user-attachments/assets/cc920ff4-ade7-4012-b7a2-d0e8a4d92784" />

Fills request: 
- #7 

Tested on Windows 11 with Firefox 150, Violentmonkey 2.37.
